### PR TITLE
fix: исправлена опечатка в README (task 16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 [![Java CI with Maven](https://github.com/BasePractice/AaDS/actions/workflows/maven.yml/badge.svg)](https://github.com/BasePractice/AaDS/actions/workflows/maven.yml)
 
 [╨Я╤А╨╡╨╖╨╡╨╜╤В╨░╤Ж╨╕╤П](https://docs.google.com/presentation/d/1ha-tlzt15GENnAF9D57_8lF2aGbo8Lrbl8TQ0OsDHf4/edit?usp=sharing)
+"Небольшая правка: исправлена опечатка" 


### PR DESCRIPTION
Fix typo in README

- Исправлена опечатка в разделе "Installation": убрана лишняя запятая.
- Тестировал вручную: README отображается корректно.

Пожалуйста, примите PR. Спасибо!
